### PR TITLE
Repeatable delayed  remove

### DIFF
--- a/src/mutation/queueRemoveRepeatable.ts
+++ b/src/mutation/queueRemoveRepeatable.ts
@@ -26,7 +26,7 @@ export function createRemoveRepeatableFC(
     resolve: async (_, { prefix, queueName, key }) => {
       const queue = await findQueue(prefix, queueName, opts);
       await queue.removeRepeatableByKey(key);
-      return {};
+      return { key };
     },
   };
 }

--- a/src/mutation/queueRemoveRepeatable.ts
+++ b/src/mutation/queueRemoveRepeatable.ts
@@ -11,9 +11,6 @@ export function createRemoveRepeatableFC(
   return {
     type: sc.createObjectTC({
       name: `${typePrefix}QueueRemoveRepeatablePayload`,
-      fields: {
-        key: 'String!',
-      },
     }),
     args: {
       prefix: {
@@ -21,12 +18,21 @@ export function createRemoveRepeatableFC(
         defaultValue: 'bull',
       },
       queueName: 'String!',
-      key: 'String!',
+      jobName: 'String',
+      repeat: sc.createInputTC({
+        name: `${typePrefix}JobOptionsInputRepeatRemove`,
+        fields: {
+          tz: 'String',
+          endDate: 'Date',
+          cron: 'String',
+          every: 'String',
+        },
+      }).NonNull,
     },
-    resolve: async (_, { prefix, queueName, key }) => {
+    resolve: async (_, { prefix, queueName, jobName, repeat }) => {
       const queue = await findQueue(prefix, queueName, opts);
-      await queue.removeRepeatableByKey(key);
-      return { key };
+      await queue.removeRepeatable(jobName, repeat);
+      return {};
     },
   };
 }


### PR DESCRIPTION
Change bullmq remove method for queueRemoveRepeatable, now repeatable key and current delayed job both are deleted.